### PR TITLE
Added Promise alternative to "getSendTransaction"

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -158,6 +158,19 @@ describe('TrxDepositUtils', function () {
         done()
       })
     })
+    it('Generate a send transaction (Promise)', async function (done) {
+      let amountInSun = 12323
+      let to = TrxDepositUtils.bip44(xpubOnPath, 6)
+      try {
+        const signedtx = await TrxDepositUtils.getSendTransaction(privateKey, amountInSun, to)
+        expect(signedtx).to.exist
+        expect(signedtx.signedTx.raw_data.contract[0].parameter.value.amount).to.equal(12323)
+        signedSendTransaction = signedtx.signedTx
+        done()
+      } catch (e) {
+        console.log(e)
+      }
+    })
   }
   let broadcast = false
   if (broadcast) {


### PR DESCRIPTION
Hey go-faast,

I wanted to add a Promise alternative to your `getSendTransaction` function that is not "balance-safe" and does not check to ensure the user has enough balance to transact. I thought you might find it useful, within the branch I tried to follow your code-style as much as possible (no ";" at the end of lines etc.) and I also added a test-case for the new `Promise` function. 